### PR TITLE
feat: add copy-to-clipboard button with success toast (closes #90)

### DIFF
--- a/app/dashboard/content/[template-slug]/_components/OutputSection.tsx
+++ b/app/dashboard/content/[template-slug]/_components/OutputSection.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef } from 'react';
 // import { Editor } from '@toast-ui/react-editor';
 import { Button } from '@/components/ui/button';
 import { Copy } from 'lucide-react';
+import toast from 'react-hot-toast';
 
 interface Props {
   aiOutput: string;
@@ -32,12 +33,24 @@ function OutputSection({ aiOutput }: Props) {
   //   }
   // };
 
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(aiOutput || '');
+      toast.success('Copied!');
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+      toast.error('Failed to copy');
+    }
+  };
+
   return (
     <div className='bg-white rounded-lg shadow-lg border'>
       <div className='flex justify-between items-center p-5'>
         <h2 className='text-black font-medium text-lg'>Your Result</h2>
-        <Button className='flex gap-2' onClick={()=>navigator.clipboard.writeText(aiOutput)}>
-         
+        <Button
+          className='flex gap-2'
+          onClick={handleCopy}
+        >
           <Copy className='w-4 h-4' /> Copy
         </Button>
       </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { ClerkProvider } from "@clerk/nextjs";
+import AppToaster from '@/components/ui/toaster';
 import { Outfit } from "next/font/google";
 import ChatbaseEmbed from "@/components/ChatbaseEmbed";
 
@@ -33,6 +34,7 @@ export default function RootLayout({
     <ClerkProvider>
       <html lang="en">
         <body className={outfit.className}>
+          <AppToaster />
           <main>
             {children}
             <ChatbaseEmbed />

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import React from "react";
+import { Toaster } from "react-hot-toast";
+
+export default function AppToaster() {
+  return <Toaster position="top-right" />;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "next-theme": "^0.1.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hot-toast": "^2.4.0",
         "react-icons": "^5.3.0",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7"
@@ -2371,6 +2372,15 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/goober": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz",
+      "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3158,6 +3168,29 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/react-hot-toast/node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/react-icons": {
       "version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "next-theme": "^0.1.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hot-toast": "^2.4.0",
     "react-icons": "^5.3.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7"


### PR DESCRIPTION
## What does this PR do?

Adds a 'Copy to Clipboard' button next to the generated output panel, allowing users to quickly copy content instead of manually highlighting text. It integrates an asynchronous handleCopy function using the native Clipboard API and triggers a sleek success toast notification ('Copied!') using `react-hot-toast` to instantly improve user  experience.

Fixes #90 

<img width="1920" height="989" alt="Screenshot 2026-05-18 134817" src="https://github.com/user-attachments/assets/cd86f437-c26b-43bf-bc7f-8f99b1e806d5" />


## Type of change

 - [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- **Test A:** Clicked the new 'Copy to Clipboard' button and verified that the exact generated text was copied to the clipboard by successfully pasting it elsewhere.
- **Test B:** Verified that the success toast notification with the message 'Copied!' triggers instantly upon a successful copy action and dismisses itself correctly.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.