### PR TITLE
Fix: redirect unauthenticated users to Clerk sign-in instead of returning 401

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -7,7 +7,7 @@ export default clerkMiddleware(async (auth, request) => {
   if (!isPublicRoute(request)) {
     const session = await auth();
     if (!session.userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
+      return NextResponse.redirect(new URL("/sign-in", request.url));
     }
   }
   return NextResponse.next();


### PR DESCRIPTION
### Description
When an unauthenticated user clicks "Get Started" (which links to /dashboard), the Clerk middleware returns a raw 401 Unauthorized response instead of redirecting to the sign-in page. This happens because the middleware checks session.userId and returns a plain text 401 error.

Fixed by replacing the 401 response with NextResponse.redirect() to the Clerk sign-in page. The existing NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/dashboard env var will then redirect users back to /dashboard after successful sign-in.

### Related Issue
Fixes #128

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

program: gssoc