### PR TITLE
Feat: add loading skeletons during AI content generation

### DIFF
--- a/app/dashboard/content/[template-slug]/_components/OutputSection.tsx
+++ b/app/dashboard/content/[template-slug]/_components/OutputSection.tsx
@@ -1,16 +1,15 @@
 import React, { useEffect, useState } from 'react';
-// import '@toast-ui/editor/dist/toastui-editor.css';
-// import { Editor } from '@toast-ui/react-editor';
 import { Button } from '@/components/ui/button';
 import { CheckCircle2, Copy, XCircle } from 'lucide-react';
 
 interface Props {
   aiOutput: string;
+  loading?: boolean;
 }
 
 const TOAST_DISPLAY_DURATION = 2000;
 
-function OutputSection({ aiOutput }: Props) {
+function OutputSection({ aiOutput, loading }: Props) {
   const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [isErrorToast, setIsErrorToast] = useState(false);
   const [toastId, setToastId] = useState(0);
@@ -44,7 +43,7 @@ function OutputSection({ aiOutput }: Props) {
       <div className='flex justify-between items-center p-5'>
         <h2 className='text-black font-medium text-lg'>Your Result</h2>
         <div className='relative'>
-          <Button className='flex gap-2' onClick={handleCopy} disabled={!aiOutput?.trim()}>
+          <Button className='flex gap-2' onClick={handleCopy} disabled={!aiOutput?.trim() || loading}>
             <Copy className='w-4 h-4' /> Copy
           </Button>
           {toastMessage && (
@@ -60,6 +59,23 @@ function OutputSection({ aiOutput }: Props) {
           )}
         </div>
       </div>
+
+      {loading ? (
+        <div className="p-5 space-y-4 animate-pulse">
+          <div className="h-4 bg-gray-200 rounded w-3/4" />
+          <div className="h-4 bg-gray-200 rounded w-1/2" />
+          <div className="h-4 bg-gray-200 rounded w-5/6" />
+          <div className="h-4 bg-gray-200 rounded w-2/3" />
+          <div className="h-4 bg-gray-200 rounded w-4/5" />
+          <div className="h-4 bg-gray-200 rounded w-3/5" />
+          <div className="h-4 bg-gray-200 rounded w-5/6" />
+          <div className="h-4 bg-gray-200 rounded w-1/3" />
+        </div>
+      ) : aiOutput ? (
+        <div className="p-5 text-gray-700 whitespace-pre-wrap">{aiOutput}</div>
+      ) : (
+        <div className="p-5 text-gray-400">Your result will be displayed here</div>
+      )}
     </div>
   );
 }

--- a/app/dashboard/content/[template-slug]/page.tsx
+++ b/app/dashboard/content/[template-slug]/page.tsx
@@ -110,7 +110,7 @@ function CreateNewContent(props: PROPS) {
 
         {/* Output Section */}
         <div className="col-span-2">
-          <OutputSection aiOutput={aiOutput} />
+          <OutputSection aiOutput={aiOutput} loading={loading} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Description
When AI content is being generated, the OutputSection currently shows nothing while the tiny spinner on the Generate button is the only loading indicator. This adds animated pulse skeleton placeholders in the output area during generation, providing clear visual feedback that content is being prepared.

Changes:
- Added loading prop to OutputSection component
- Display animated skeleton placeholders (pulse animation) when loading
- Show the generated content when ready, or a placeholder message when empty
- Disable the Copy button while loading

### Related Issue
Fixes #123

### Type of Change
- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

program: gssoc