### PR TITLE
fix: center sign-up form on large screens

### DIFF
--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -1,5 +1,9 @@
 import { SignUp } from '@clerk/nextjs'
 
 export default function Page() {
-  return <SignUp />
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <SignUp />
+    </div>
+  )
 }


### PR DESCRIPTION
The sign-up page was missing a flexbox centering wrapper that the sign-in page already has. Added `flex items-center justify-center h-screen` wrapper div to the sign-up page so the auth form appears centered on all screen sizes.

Closes #145