### PR TITLE
refactor: update createdAt in AIOutput schema to native timestamp

### DIFF
--- a/utils/schema.tsx
+++ b/utils/schema.tsx
@@ -1,13 +1,10 @@
-import { pgTable, serial, text, varchar } from "drizzle-orm/pg-core";
-// Verify the schema file is in the utils directory
-import * as schema from '@/utils/schema'; // Update as needed
+import { pgTable, serial, text, varchar, timestamp } from "drizzle-orm/pg-core";
 
-export const AIOutput=pgTable('aiOutput',{
-    id:serial('id').primaryKey(),
-    formData:varchar('formData').notNull(),
-    aiResponse:text('aiResponse'),
-    templateSlug:varchar('templateSlug').notNull(),
-    createdBy:varchar('createdBy').notNull(),
-    createdAt:varchar('createdAt')
-    
-})
+export const AIOutput = pgTable('aiOutput', {
+  id: serial('id').primaryKey(),
+  formData: varchar('formData').notNull(),
+  aiResponse: text('aiResponse'),
+  templateSlug: varchar('templateSlug').notNull(),
+  createdBy: varchar('createdBy').notNull(),
+  createdAt: timestamp('createdAt').defaultNow().notNull()
+});


### PR DESCRIPTION
## What does this PR do?

This PR refactors the `createdAt` column in the `AIOutput` schema to use PostgreSQL's native `timestamp` with a `.defaultNow().notNull()` constraint. This will ensure better database performance, proper chronological sorting, and allow the use of native date functions. 

The redundant self-import (`import * as schema`) was also removed to prevent circular dependency warnings.

Fixes #169

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How should this be tested?

1. Pull the branch locally.
2. Run your Drizzle migration/push command (e.g., `npm run db:push` or similar).
3. Insert a new record into the `AIOutput` table; it should automatically generate the current timestamp for `createdAt`.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.