### PR TITLE
fix: optimize AI temperature and topP settings for consistent content quality

### DIFF
--- a/utils/AiModal.tsx
+++ b/utils/AiModal.tsx
@@ -17,9 +17,9 @@ const {
     model: "gemini-1.5-flash",
   });
   
-  const generationConfig = {
-    temperature: 1,
-    topP: 0.95,
+ const generationConfig = {
+    temperature: 0.5, // Reduced from 1 to 0.5 for stable, high-quality, and factual output
+    topP: 0.9,        // Slightly tightened from 0.95 to maintain logical focus
     topK: 64,
     maxOutputTokens: 8192,
     responseMimeType: "text/plain",


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue of inconsistent and nonsensical AI-generated content. The root cause was that the `temperature` parameter in the Gemini `generationConfig` was set to `1`, which forces the model into an overly creative state, leading to frequent hallucinations and unreliable outputs.

**Changes Made:**
- Lowered `temperature` from `1` to `0.5` to ensure professional, factual, and consistent content generation.
- Adjusted `topP` from `0.95` to `0.9` to tighten the model's logical focus and prevent it from picking out-of-context tokens.

Fixes #161

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How should this be tested?

1. Pull this branch and run the app locally.
2. Generate any blog content or article using a generic prompt.
3. Observe that the output is now highly structured, makes logical sense, and maintains a professional tone without hallucinating facts.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.